### PR TITLE
Feature/add product query suggestions schema

### DIFF
--- a/packages/core/types/src/product/service.ts
+++ b/packages/core/types/src/product/service.ts
@@ -194,6 +194,20 @@ export interface IProductModuleService extends IModuleService {
   ): Promise<[ProductDTO[], number]>
 
   /**
+   * This method is used to retrieve a list of random products.
+   *
+   * @param {number} count - The number of random products to retrieve.
+   * @param {Context} sharedContext - A context used to share resources, such as transaction manager, between the application and the module.
+   * @returns {Promise<ProductDTO[]>} The list of random products.
+   *
+   * @example
+   * const randomProducts = await productModuleService.listRandomProducts(5)
+   */
+  listRandomProducts(
+    count: number,
+    sharedContext?: Context
+  ): Promise<ProductDTO[]>
+  /**
    * This method is used to create a list of products.
    *
    * @param {CreateProductDTO[]} data - The products to be created.

--- a/packages/modules/product/src/services/product-module-service.ts
+++ b/packages/modules/product/src/services/product-module-service.ts
@@ -223,6 +223,29 @@ export default class ProductModuleService
     return [serializedProducts, count]
   }
 
+   @InjectManager()
+  // @ts-ignore
+  async listRandomProducts(
+    count: number,
+    @MedusaContext() sharedContext?: Context
+  ): Promise<ProductTypes.ProductDTO[]> {
+    const allProducts = await this.listProducts({}, {}, sharedContext)
+
+    if (count >= allProducts.length) {
+      return allProducts
+    }
+
+    const randomProducts: ProductTypes.ProductDTO[] = []
+    const availableProducts = [...allProducts] // Create a mutable copy
+
+    for (let i = 0; i < count; i++) {
+      const randomIndex = Math.floor(Math.random() * availableProducts.length)
+      randomProducts.push(availableProducts.splice(randomIndex, 1)[0])
+    }
+
+    return randomProducts
+  }
+  
   protected getProductFindConfig_(
     config?: FindConfig<ProductTypes.ProductDTO>
   ): FindConfig<ProductTypes.ProductDTO> {


### PR DESCRIPTION
This pull request introduces a new feature to retrieve a list of random products in the `ProductModuleService`. The most important changes include adding a new method to the `IProductModuleService` interface and implementing the corresponding logic in the `ProductModuleService` class.

### New Feature: List Random Products

* **Interface Update**: Added the `listRandomProducts` method to the `IProductModuleService` interface in `packages/core/types/src/product/service.ts`. This method retrieves a specified number of random products and includes documentation with an example of usage.
* **Implementation**: Implemented the `listRandomProducts` method in the `ProductModuleService` class in `packages/modules/product/src/services/product-module-service.ts`. The method selects random products from the full list of products, ensuring no duplicates, and supports an optional shared context.